### PR TITLE
Fix formatting in Docker run command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ We use tencent/Hunyuan-7B-Instruct for example
 docker pull docker.cnb.cool/tencent/hunyuan/hunyuan-7b:hunyuan-7b-trtllm
 ```
 ```
-docker run --privileged --user root --name hunyuanLLM_infer --rm -it --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 --gpus=all hunyuaninfer/hunyuan-7B:hunyuan-7b-trtllm
+docker run --privileged --user root --name hunyuanLLM_infer --rm -it --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 --gpus=all hunyuaninfer/hunyuan-7b:hunyuan-7b-trtllm
 ```
 
 - Prepare Configuration file:


### PR DESCRIPTION
 Fix Docker run command: image name must be lowercase (`hunyuan-7B` → `hunyuan-7b`)