### PR TITLE
fix README_CN.md typo

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -123,7 +123,7 @@ messages = [
 ]
 tokenized_chat = tokenizer.apply_chat_template(
     messages,
-    tokenize=True
+    tokenize=True,
     add_generation_prompt=False,
     return_tensors="pt"
 )


### PR DESCRIPTION
英文版readme和中文版差一个逗号